### PR TITLE
Standardize and correct GCPNetPredictor output positions scaling

### DIFF
--- a/configs/config_gcpnet.yaml
+++ b/configs/config_gcpnet.yaml
@@ -36,6 +36,8 @@ model:
     edge_s_emb_dim: 32 # Dimension of the edge state embeddings
     edge_v_emb_dim: 4 # Dimension of the edge vector embeddings
 
+    pos_scale_factor: 10.0  # By how much to upscale `GCPNetPredictor`'s output positions
+
     # GCPNet module config #
     module_cfg:
       norm_pos_diff: true

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -645,7 +645,7 @@ class GCPNetDataset(Dataset):
 
         coords_tensor = self.handle_nan_coordinates(coords_tensor)
         # coords_tensor = self.processor.normalize_coords(coords_tensor)
-        coords_tensor = coords_tensor / 10
+        # coords_tensor = coords_tensor / 10
 
         coords_tensor = coords_tensor.reshape(1, -1, 12)
         # Merge the features and create a mask


### PR DESCRIPTION
* Standardizes and corrects the `GCPNetPredictor`'s output position scaling. Note that, when scaling the output positions by 10 (and doing nothing else), the model's weights need to be calibrated (slowly through backprop) to predict coordinate shifts in nanometers. This takes a few hundred epochs to achieve, but once it's done, the model is much more stable (in terms of gradient norms) and robust (in terms of its possible range of coordinate shifts it can predict and how large they can be for huge complexes). This coordinate shifting is inspired by works such as SE(3) diffusion for protein backbone generation, which introduced a lot of these important coordinate scaling techniques for generative models.
* After 500 epochs of training (1 step each, where the loss starts out around 88), I can successfully overfit using the default config launched by running `python3 train_gcpnet.py` within the state of this PR. The next step I would recommend taking is trying to reproduce this result (n.b., takes around 10 minutes on my local machine) and then visualizing the output PDB structures to make sure they look realistic (and that the metrics and loss aren't misleading us).
![image](https://github.com/user-attachments/assets/cc369eae-9ca7-48e0-96fd-db34a884b5c4)
